### PR TITLE
Cleaner URLs and new dev scripts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,5 @@ plugins:
   - jekyll-ical-tag
 
 timezone: Europe/Paris
+
+permalink: /:title

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,20 +2,20 @@
   url: /
 
 - text: Members
-  url: /members.html
+  url: /members
 
 - text: Publications
-  url: /publications.html
+  url: /publications
 
 - text: Projects
-  url: /projects.html
+  url: /projects
 
 - text: Openings
-  url: /openings.html
+  url: /openings
   
 - text: Software
   url: http://www.atlanmod.org
 
 - text: Weekly Seminar
-  url: /seminars.html
+  url: /seminars
 

--- a/run_with_docker.sh
+++ b/run_with_docker.sh
@@ -1,3 +1,17 @@
 #!/bin/bash
 
-sudo docker run -p 4000:4000 -v $(pwd):/site bretfisher/jekyll-serve
+set -x
+set -e
+
+mkdir -p bundle
+
+docker rm -f jekyll
+
+docker run --rm \
+  -ti \
+  --volume="$PWD:/srv/jekyll:Z" \
+  --volume="$PWD/bundle:/usr/local/bundle:Z" \
+  --publish [::1]:4000:4000 \
+  --name jekyll \
+  jekyll/minimal \
+  bash serve.sh

--- a/run_with_podman.sh
+++ b/run_with_podman.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# podman rm -f jekyll
-# podman run --rm \
-#     -p 4000:4000  \
-#     -v $(pwd):/site:Z \
-#     --name jekyll \
-#     bretfisher/jekyll-serve
-
 set -x
 set -e
 


### PR DESCRIPTION
This PR does two things:

1. Makes sure that inner URLs are now without a trialing `.html` (eg. https://naomod.github.io/publications.html will become https://naomod.github.io/publications)
2. Update the docker dev scripts to use the Jekyll official image, and add a similar podman dev script.